### PR TITLE
Swaps leave and end button logic

### DIFF
--- a/app/src/main/java/com/zoomvideosdkkotlin/activities/InSession.kt
+++ b/app/src/main/java/com/zoomvideosdkkotlin/activities/InSession.kt
@@ -101,10 +101,10 @@ class InSession : AppCompatActivity() {
             }
         }
         findViewById<MaterialButton>(R.id.leavebtn).apply {
-            setOnClickListener { zoomSessionViewModel.closeSession(true) }
+            setOnClickListener { zoomSessionViewModel.closeSession(false) }
         }
         findViewById<MaterialButton>(R.id.endbtn).apply {
-            setOnClickListener { zoomSessionViewModel.closeSession(false) }
+            setOnClickListener { zoomSessionViewModel.closeSession(true) }
         }
         findViewById<TextView>(R.id.title).text = config.sessionName
 


### PR DESCRIPTION
## This PR corrects the behavior of the Leave and End call buttons, which were previously reversed.

- Leave: Now correctly ends the session for all participants.
- End: Now allows the current user to leave the session without ending it for others.

Closes #1 